### PR TITLE
ci: test inside nix devshell

### DIFF
--- a/.github/workflows/check_formatting_and_run_tests.yml
+++ b/.github/workflows/check_formatting_and_run_tests.yml
@@ -13,5 +13,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check formatting
       run: rustfmt --check $(find . -name '*.rs')
+    - uses: cachix/install-nix-action@v17
     - name: Run tests
-      run: cargo test --workspace
+      run: nix develop -c cargo test --workspace

--- a/.github/workflows/check_formatting_and_run_tests.yml
+++ b/.github/workflows/check_formatting_and_run_tests.yml
@@ -2,8 +2,6 @@ name: Check formatting and run tests
 on:
   push:
     branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
This PR adjusts the testing action so it happens inside the Nix devshell, which resolves issues with runs failing due to mismatched cargo versions.